### PR TITLE
Update ease factor before calculating next interval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sm-2"
-version = "0.2.0"
+version = "0.2.1"
 description = "SM-2 spaced repetition scheduler"
 readme = "README.md"
 authors = [{ name = "Joshua Hamilton", email = "hamiltonjoshuadavid@gmail.com" }]

--- a/src/sm_2/sm_2.py
+++ b/src/sm_2/sm_2.py
@@ -173,6 +173,10 @@ class SM2Scheduler:
         else:
 
             if rating >= 3: # correct response
+
+                # note: EF increases when rating = 5, stays the same when rating = 4 and decreases when rating = 3
+                card.EF = card.EF + (0.1-(5-rating)*(0.08+(5-rating)*0.02))
+                card.EF = max(1.3, card.EF)
                 
                 if card.n == 0:
 
@@ -187,10 +191,6 @@ class SM2Scheduler:
                     card.I = ceil(card.I * card.EF)
 
                 card.n += 1
-
-                # note: EF increases when rating = 5, stays the same when rating = 4 and decreases when rating = 3
-                card.EF = card.EF + (0.1-(5-rating)*(0.08+(5-rating)*0.02))
-                card.EF = max(1.3, card.EF)
 
                 if rating >= 4:
 


### PR DESCRIPTION
Closes #2 

I tried reaching out to Piotr Wozniak multiple times over email this last month and he unfortunately hasn't gotten back to me about whether one should update the ease factor before or after calculating the next interval. 

Given the above, I've decided to update the algorithm so that the ease factor is calculated before the next interval. This makes much more sense to me intuitively and is also explicitly what [supermemo.guru](https://supermemo.guru/wiki/SuperMemo_1.0_for_DOS_(1987)#Algorithm_SM-2) states should be done (despite that other resources have it the other way around).